### PR TITLE
now using modified aerogel

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,6 @@
 
   "dependencies": {
     "cylon":   "~1.1.0",
-    "aerogel": "0.0.5"
+    "aerogel": "git+https://github.com/rowellx68/aerogel.git"
   }
 }


### PR DESCRIPTION
`npm` should now pull the modified version of `aerogel` that has dependencies locked to the current versions. 
